### PR TITLE
Missing types

### DIFF
--- a/src/acorn.d.ts
+++ b/src/acorn.d.ts
@@ -477,6 +477,11 @@ export interface ImportExpression extends Node {
   source: Expression
 }
 
+export interface ParenthesizedExpression extends Node {
+  type: "ParenthesizedExpression"
+  expression: Expression
+}
+
 export interface PropertyDefinition extends Node {
   type: "PropertyDefinition"
   key: Expression | PrivateIdentifier
@@ -546,6 +551,7 @@ export type Expression =
 | AwaitExpression
 | ChainExpression
 | ImportExpression
+| ParenthesizedExpression
 
 export type Pattern = 
 | Identifier

--- a/src/acorn.d.ts
+++ b/src/acorn.d.ts
@@ -518,6 +518,7 @@ export type Statement =
 | DoWhileStatement
 | ForStatement
 | ForInStatement
+| ForOfStatement
 | Declaration
 
 export type Declaration = 


### PR DESCRIPTION
The `ParenthesizedExpression` type (which is produced by the `preserveParens` option) was missing, and `ForOfStatements` weren't part of `Statement`. I assume those were simple oversights.