### PR TITLE
Add Literal.raw

### DIFF
--- a/src/acorn.d.ts
+++ b/src/acorn.d.ts
@@ -32,6 +32,7 @@ export interface Identifier extends Node {
 export interface Literal extends Node {
   type: "Literal"
   value?: string | boolean | null | number | RegExp | bigint
+  raw?: string
   regex?: {
     pattern: string
     flags: string


### PR DESCRIPTION
Several types of literals get a `raw` property on their node object. This adds that as an optional property.

(I typed the trees produced by Acorn's tests against the `Program` type. It required only a handful of changes—see this an the other PRs—to make them pass.)